### PR TITLE
add capability to build both, static and shared libraries

### DIFF
--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -59,7 +59,7 @@ endmacro( build_shared )
 
 # the core library shared and static build
 
-#for debian packaging purpose we want to build both, shared and static with one build_command
+#for packaging purpose we want to build both, shared and static with one build_command
 #however this capability is not provided by an option in the cmake menu
 if(ISIS_BUILD_STATIC_AND_SHARED)
     build_static( isis_core_static )


### PR DESCRIPTION
To build debian packages of isis we need to build both static and shared libraries with one build.

This option is not available as a cmake-option in the ccmake but can be toggled with -DISIS_BUILD_STATIC_AND_SHARED.
