### PR TITLE
omit conversion from/to QMatrix4x4 for qt < 4.6

### DIFF
--- a/lib/Adapter/qt4/qmatrixconversion.cpp
+++ b/lib/Adapter/qt4/qmatrixconversion.cpp
@@ -50,6 +50,8 @@ util::FixedMatrix< qreal, 2, 2 > QMatrix2FixedMatrix2x2 ( const QMatrix &matrix 
 	return ret;
 }
 
+#if QT_VERSION >= 0x040600
+
 QMatrix4x4 FixedMatrix2QMatrix4x4 ( const util::Matrix4x4< qreal >& matrix )
 {
 	QMatrix4x4 ret( matrix.elem( 0, 0 ), matrix.elem( 1, 0 ), matrix.elem( 2, 0 ), matrix.elem( 3, 0 ),
@@ -73,6 +75,7 @@ util::Matrix4x4< qreal > QMatrix2FixedMatrix4x4 ( const QMatrix4x4 &matrix )
 	return ret;
 }
 
+#endif
 
 
 

--- a/lib/Adapter/qt4/qmatrixconversion.hpp
+++ b/lib/Adapter/qt4/qmatrixconversion.hpp
@@ -30,8 +30,12 @@
 #define ISIS_QMATRIXCONVERSION_HPP
 
 #include <QMatrix>
-#include <QMatrix4x4>
 #include <CoreUtils/matrix.hpp>
+
+#if QT_VERSION >= 0x040600
+#include <QMatrix4x4>
+#endif
+
 
 namespace isis
 {
@@ -41,8 +45,10 @@ namespace qt4
 isis::util::FixedMatrix<qreal, 2, 2> QMatrix2FixedMatrix2x2( const QMatrix &matrix );
 QMatrix FixedMatrix2QMatrix2x2( const util::FixedMatrix<qreal, 2, 2> &matrix );
 
+#if QT_VERSION >= 0x040600
 isis::util::Matrix4x4<qreal> QMatrix2FixedMatrix4x4( const QMatrix4x4 &matrix );
 QMatrix4x4 FixedMatrix2QMatrix4x4( const util::Matrix4x4<qreal> &matrix );
+#endif
 
 template<typename TYPE, unsigned int COLUMN, unsigned int ROW>
 isis::util::FixedMatrix<TYPE, COLUMN, ROW> QMatrix2FixedMatrix( const QGenericMatrix<ROW, COLUMN, TYPE> &matrix )


### PR DESCRIPTION
since qmatrix4x4 is only available for qt version >= 4.6 we possibly have to omit conversion to and from qmatrix4x4
