### PR TITLE
Fixes found during packaging for Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ if(NOT WIN32)
 ############################################################
 # set install infix for plugin installation path
 ############################################################
-set(ISIS_PLUGIN_INFIX lib/isis/plugins)
-set(ISIS_FILTER_INFIX lib/isis/filter)
+set(ISIS_PLUGIN_INFIX lib${LIB_SUFFIX}/isis/plugins)
+set(ISIS_FILTER_INFIX lib${LIB_SUFFIX}/isis/filter)
 endif(NOT WIN32)
 
 ############################################################

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,8 +25,8 @@ macro( build_lib name type sources deps soversion version)
 	# install libraries
 	install (TARGETS ${name}-${type}
 		RUNTIME DESTINATION bin COMPONENT RuntimeLibraries
-		LIBRARY DESTINATION lib COMPONENT RuntimeLibraries
-		ARCHIVE DESTINATION lib COMPONENT Development
+		LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT RuntimeLibraries
+		ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT Development
 	)
 	
 	set(${name}_lib ${name}-${type} CACHE INTERNAL "internal name for ${name}" FORCE)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -80,5 +80,5 @@ install(FILES ${DATASTORAGE_HDR_FILES} DESTINATION include/isis/DataStorage COMP
 configure_file(cmake/isis_corecfg.cmake.in ${CMAKE_BINARY_DIR}/ISISConfig.cmake @ONLY)
 
 # install cmake configuration files
-install(FILES ${CMAKE_BINARY_DIR}/ISISConfig.cmake DESTINATION share/isis/cmake COMPONENT Development)
+install(FILES ${CMAKE_BINARY_DIR}/ISISConfig.cmake DESTINATION lib${LIB_SUFFIX}/cmake/ISIS COMPONENT Development)
 


### PR DESCRIPTION
1. libraries should be installed per-arch directory - lib64 for 64 bit and lib for 32bit
2. the same for CMake